### PR TITLE
fix: ctrl on non-mac platforms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,13 @@ function useAddPageTab(cb: (e: ITabInfo) => void) {
   React.useEffect(() => {
     const listener = (e: MouseEvent) => {
       const target = e.composedPath()[0] as HTMLAnchorElement;
+      const key = navigator.platform.toUpperCase().indexOf('MAC')>=0 ? e.metaKey : e.ctrlKey;
       if (
         target.tagName === "A" &&
         target.hasAttribute("data-ref") &&
         (target.className.includes("page-ref") ||
           target.className.includes("tag")) &&
-        e.metaKey
+        key
       ) {
         cb({
           ref: target.getAttribute("data-ref")!,


### PR DESCRIPTION
Could you explain `[data-active-keystroke*="Meta"]`?
I guess it changes the cursor when `Cmd` key is active, but replacing it with Ctrl did nothing. I couldn't find where it is documented.

So I've left it untouched, did not add any media queries.