### PR TITLE
feat: add button for closing all tabs

### DIFF
--- a/src/PageTabs.css
+++ b/src/PageTabs.css
@@ -54,3 +54,11 @@
   @apply light:(bg-cool-gray-400)
          dark:(bg-cool-gray-600);
 }
+
+.close-all {
+  opacity: 0;
+}
+
+.logseq-tab-wrapper:hover .close-all {
+ opacity: 1;
+}

--- a/src/PageTabs.tsx
+++ b/src/PageTabs.tsx
@@ -58,12 +58,13 @@ interface TabsProps {
   activeTab: ITabInfo | null | undefined;
   onClickTab: (tab: ITabInfo) => void;
   onCloseTab: (tab: ITabInfo, force?: boolean) => void;
+  onCloseAllTabs: (excludeActive: boolean) => void;
   onPinTab: (tab: ITabInfo) => void;
   onSwapTab: (tab: ITabInfo, anotherTab: ITabInfo) => void;
 }
 
 const Tabs = React.forwardRef<HTMLElement, TabsProps>(
-  ({ activeTab, onClickTab, tabs, onCloseTab, onPinTab, onSwapTab }, ref) => {
+  ({ activeTab, onClickTab, tabs, onCloseTab, onCloseAllTabs, onPinTab, onSwapTab }, ref) => {
     const [draggingTab, setDraggingTab] = React.useState<ITabInfo>();
 
     React.useEffect(() => {
@@ -83,7 +84,7 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
         // @ts-expect-error ???
         ref={ref}
         data-dragging={draggingTab != null}
-        className={`flex items-center h-full px-1`}
+        className={`logseq-tab-wrapper flex items-center h-full px-1`}
         style={{ width: "fit-content" }}
         // By default middle button click will enter the horizontal scroll mode
         onMouseDown={(e) => {
@@ -154,6 +155,16 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
             </div>
           );
         })}
+        <div
+              onClick={() => onCloseAllTabs(true)}
+              key={"Close All"}
+              draggable={false}
+              className="logseq-tab close-all group"
+            >
+              <span className="logseq-tab-title">
+                Close All
+              </span>
+            </div>
       </div>
     );
   }
@@ -560,6 +571,7 @@ export function PageTabs(): JSX.Element {
       onSwapTab={onSwapTab}
       onPinTab={onPinTab}
       onCloseTab={onCloseTab}
+      onCloseAllTabs={onCloseAllTabs}
     />
   );
 }


### PR DESCRIPTION
I saw that there was already functionality to close all tabs, so I just added a button that appears on hover to run the function.

Right now it defaults to closing all but the active tab and pinned tabs, but let me know if you have any suggestions functionality or style -wise.