### PR TITLE
Add setting to hide a single tab

### DIFF
--- a/src/PageTabs.tsx
+++ b/src/PageTabs.tsx
@@ -55,6 +55,7 @@ function isTabEqual(
 
 interface TabsProps {
   tabs: ITabInfo[];
+  showSingleTab: boolean;
   activeTab: ITabInfo | null | undefined;
   onClickTab: (tab: ITabInfo) => void;
   onCloseTab: (tab: ITabInfo, force?: boolean) => void;
@@ -69,6 +70,7 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
       activeTab,
       onClickTab,
       tabs,
+      showSingleTab,
       onCloseTab,
       onCloseAllTabs,
       onPinTab,
@@ -89,7 +91,11 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
     }, []);
 
     const debouncedSwap = useDebounceFn(onSwapTab, 0);
+    const showTabs = showSingleTab || 0 < tabs.filter(tab => tab.pinned).length || 1 < tabs.length;
 
+    if (!showTabs) {
+      return null;
+    }
     return (
       <div
         // @ts-expect-error ???
@@ -485,6 +491,7 @@ export function PageTabs(): JSX.Element {
 
   const currActiveTabRef = React.useRef<ITabInfo | null>();
   const latestTabsRef = useLatest(tabs);
+  const showSingleTab = logseq.settings["tabs:show-single-tab"];
 
   const onCloseTab = useEventCallback((tab: ITabInfo, force?: boolean) => {
     const idx = tabs.findIndex((t) => isTabEqual(t, tab));
@@ -667,6 +674,7 @@ export function PageTabs(): JSX.Element {
       onClickTab={onChangeTab}
       activeTab={activeTab}
       tabs={tabs}
+      showSingleTab={showSingleTab}
       onSwapTab={onSwapTab}
       onPinTab={onPinTab}
       onCloseTab={onCloseTab}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,7 +16,7 @@ export const keyBindings = {
   "tabs:select-prev": {
     label: "Select Previous Tab",
     binding: "ctrl+shift+tab",
-  },
+  }
 };
 
 const keybindingSettings: SettingSchemaDesc[] = Object.entries(keyBindings).map(
@@ -43,7 +43,16 @@ export const inheritCustomCSSSetting: SettingSchemaDesc = {
   type: "boolean",
 };
 
+export const showSingleTab: SettingSchemaDesc = {
+  key: "tabs:show-single-tab",
+  title: "Show single tab?",
+  description: "When turned on the tab bar will only show if at least two tabs are open.",
+  type: "boolean",
+  default: true,
+}
+
 export const settings: SettingSchemaDesc[] = [
   ...keybindingSettings,
   inheritCustomCSSSetting,
+  showSingleTab,
 ];


### PR DESCRIPTION
This PR adds a setting to hide the tab bar if there is only one tab. The default setting is the current behaviour. 

Tabs are shown when there are more than one tabs or at least one pinned tab.

Closes: https://github.com/pengx17/logseq-plugin-tabs/issues/40