### PR TITLE
fix: opening a new tab from favorites in sidebar 

### DIFF
--- a/src/PageTabs.tsx
+++ b/src/PageTabs.tsx
@@ -212,7 +212,8 @@ function getPageRef(element: HTMLElement) {
     getBlockContentPageRef(el) ??
     getSidebarPageRef(el) ??
     getReferencesPageRef(el) ??
-    getSearchMenuPageRef(el)
+    getSearchMenuPageRef(el) ??
+    getFavoritesOrRecentPageRef(el)
   );
 }
 
@@ -250,6 +251,17 @@ function getReferencesPageRef(element: HTMLElement) {
   }
 }
 
+function getFavoritesOrRecentPageRef(element: HTMLElement) {
+  const el = element as HTMLAnchorElement;
+  if (el.tagName === "SPAN" && el.classList.contains("page-title")) {
+    const parentListItem = el.closest("li");
+
+    if (parentListItem?.classList.contains("favorite-item") || parentListItem?.classList.contains("recent-item")) {
+      return parentListItem.getAttribute("data-ref");
+    }
+  }
+}
+
 function getClosestSearchMenuLink(element: HTMLElement): HTMLElement | null {
   return element.closest(".search-results-wrap .menu-link");
 }
@@ -276,6 +288,7 @@ function getBlockUUID(element: HTMLElement) {
 function stop(e: Event) {
   e.stopPropagation();
   e.stopImmediatePropagation();
+  e.preventDefault(); // prevent scrolling from middle mouse button click
 }
 
 /**


### PR DESCRIPTION
Hi,
I've implemented two things:

- opening a new tab is now also possible from favorites or recent files (solves [#68](https://github.com/pengx17/logseq-plugin-tabs/issues/68))
- middle mouse button click on a page ref will no longer start scrolling