### PR TITLE
fix: page padding

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,7 +255,7 @@ export function useAdaptMainUIStyle(show: boolean, tabsWidth?: number | null) {
     logseq.provideStyle({
       key: "tabs--top-padding",
       style: `
-      #main-content-container {
+      .cp__sidebar-main-content {
         padding-top: ${shouldShow ? "64px" : ""};
       }`,
     });


### PR DESCRIPTION
move padding 1 level down, cose on old one default Logseq paddings

![image](https://user-images.githubusercontent.com/137919/223305195-c67440c9-b0c8-4e60-b5cb-567c43b4d368.png)
