### PR TITLE
fix: a bug where a tab for a block is converted to a Journals tab when activating it

### DIFF
--- a/src/PageTabs.tsx
+++ b/src/PageTabs.tsx
@@ -41,7 +41,7 @@ function isTabEqual(
   function isEqual(a?: string, b?: string) {
     return a != null && b != null && a.toLowerCase() === b.toLowerCase();
   }
-  if (tab?.name == getJournalsString() && !anotherTab?.name) {
+  if (tab?.name == getJournalsString() && !anotherTab?.uuid) { // not possible to check 'anotherTab.name == undefined' for Journal, because a tab for a block also has no name
     return true;
   }
 


### PR DESCRIPTION
I've fixed a bug where a tab for a block is converted to a Journals tab when activating it...