### PR TITLE
Hide block link and UUID markup from tab titles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,8 @@ UX is mainly brought from modern browsers:
 Hint: you can change them in the Settings. After change, you need to restart the app.
 
 ![](./keybinding-settings.png)
+
+## Contributing
+
+- Please follow [Logseq's guidelines](https://github.com/logseq/logseq/blob/master/CONTRIBUTING.md) for contributions and Pull Requests.
+- See the [logseq-plugin-template-react readme](https://github.com/pengx17/logseq-plugin-template-react?tab=readme-ov-file#how-to-get-started) for steps on how to build and test this plugin.

--- a/src/PageTabs.tsx
+++ b/src/PageTabs.tsx
@@ -98,6 +98,13 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
       };
     }, []);
 
+    // Clean out link markup and internal block metadata from text shown in tab titles.
+    const cleanBlockTitle = (text: string): string => (
+      text
+        .replace(/\[([^\]]+)\]\([^\)]+\)/, "$1")
+        .replace(/\s+(id|background-color|collapsed):: .+/g, "")
+    )
+
     const debouncedSwap = useDebounceFn(onSwapTab, 0);
     const showTabs =
       showSingleTab ||
@@ -179,9 +186,9 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
               <span className="logseq-tab-title">
                 {tab.originalName ?? tab.name}{" "}
                 {isBlock(tab) && (
-                  <span title={tab.content}>
+                  <span title={cleanBlockTitle(tab.content)}>
                     <strong className="text-blue-600">•</strong>
-                    <span className="mx-1">{tab.content}</span>
+                    <span className="mx-1">{cleanBlockTitle(tab.content)}</span>
                   </span>
                 )}
               </span>


### PR DESCRIPTION
When zoomed into a block, tab titles were including all the ugly markdown formatting and Logseq-internal block metadata (eg. uuid, background-color, collapsed status). This change cleans up tab title text a bit for readability.

Also adds a "Contributing" section to the readme with basic pointers.

Before:
<img width="640" alt="Screenshot 2024-02-07 at 9 04 35 AM" src="https://github.com/pengx17/logseq-plugin-tabs/assets/4580894/f4de0a58-9ce9-42ce-9fbd-fa4b437896f5">

After:
<img width="636" alt="Screenshot 2024-02-07 at 9 05 01 AM" src="https://github.com/pengx17/logseq-plugin-tabs/assets/4580894/49addca9-913a-418b-95db-d0cb981eccb6">
