### PR TITLE
feat: fork plugin with scrollable tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+.worktrees/

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
-  "name": "logseq-plugin-tabs",
-  "version": "1.19.4",
+  "name": "logseq-plugin-tabs-scrollable",
+  "version": "1.20.0",
   "schemaVersion": "1.0.0",
   "main": "dist/index.html",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "vitest run --passWithNoTests",
     "preinstall": "npx only-allow pnpm"
   },
+  "description": "A maintained fork of logseq-plugin-tabs with wheel scrolling for overflowing tabs.",
   "license": "MIT",
   "dependencies": {
     "@logseq/libs": "^0.0.15",
@@ -36,9 +38,10 @@
     "vite": "3.2.2",
     "vite-plugin-logseq": "^1.1.2",
     "vite-plugin-windicss": "1.8.8",
+    "vitest": "^0.34.6",
     "windicss": "3.5.6"
   },
   "logseq": {
-    "id": "_pengx17-logseq-tabs"
+    "id": "_logseq-plugin-tabs-scrollable"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ devDependencies:
   vite-plugin-windicss:
     specifier: 1.8.8
     version: 1.8.8(vite@3.2.2)
+  vitest:
+    specifier: ^0.34.6
+    version: 0.34.6
   windicss:
     specifier: 3.5.6
     version: 3.5.6
@@ -446,6 +449,13 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+    dev: true
+
   /@jridgewell/gen-mapping@0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -475,6 +485,10 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
     dev: true
 
   /@jridgewell/trace-mapping@0.3.17:
@@ -779,9 +793,25 @@ packages:
       - supports-color
     dev: true
 
+  /@sinclair/typebox@0.27.10:
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+    dev: true
+
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+    dev: true
+
+  /@types/chai-subset@1.3.6(@types/chai@4.3.20):
+    resolution: {integrity: sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==}
+    peerDependencies:
+      '@types/chai': <5.2.0
+    dependencies:
+      '@types/chai': 4.3.20
+    dev: true
+
+  /@types/chai@4.3.20:
+    resolution: {integrity: sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==}
     dev: true
 
   /@types/js-cookie@2.2.7:
@@ -794,6 +824,12 @@ packages:
 
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+    dev: true
+
+  /@types/node@25.9.1:
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+    dependencies:
+      undici-types: 7.24.6
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -981,6 +1017,44 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/expect@0.34.6:
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+    dependencies:
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.5.0
+    dev: true
+
+  /@vitest/runner@0.34.6:
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+    dependencies:
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot@0.34.6:
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+    dependencies:
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@0.34.6:
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/utils@0.34.6:
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
   /@windicss/config@1.8.8:
     resolution: {integrity: sha512-kNas/zMkwsDFMcJPmHoPDJlQi1MHvYwx8BSxo9JKcbCW7Gaj8Rg2CnEImX5YdT+ZcFQqQ+kUn0Vi/ScsAxhGEw==}
     dependencies:
@@ -1023,6 +1097,19 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.1
+    dev: true
+
+  /acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.16.0
+    dev: true
+
+  /acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
     dev: true
 
   /acorn@8.8.1:
@@ -1083,6 +1170,11 @@ packages:
       color-convert: 2.0.1
     dev: true
 
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
     dev: true
@@ -1130,6 +1222,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
+
   /at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
@@ -1172,6 +1268,11 @@ packages:
       update-browserslist-db: 1.0.10(browserslist@4.21.4)
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -1210,6 +1311,19 @@ packages:
       redeyed: 2.1.1
     dev: true
 
+  /chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+    dev: true
+
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1230,6 +1344,12 @@ packages:
   /chalk@5.1.2:
     resolution: {integrity: sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /clean-stack@2.2.0:
@@ -1284,6 +1404,10 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    dev: true
+
+  /confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
 
   /conventional-changelog-angular@5.0.13:
@@ -1454,6 +1578,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.1.0
+    dev: true
+
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -1487,6 +1618,11 @@ packages:
 
   /deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /dir-glob@3.0.1:
@@ -2208,6 +2344,10 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
   /get-intrinsic@1.1.3:
     resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
     dependencies:
@@ -2765,6 +2905,11 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
+    dev: true
+
   /locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -2829,6 +2974,12 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -2854,6 +3005,12 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
   /map-obj@1.0.1:
@@ -2970,6 +3127,15 @@ packages:
 
   /minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+    dev: true
+
+  /mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
     dev: true
 
   /modify-values@1.0.1:
@@ -3279,6 +3445,13 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
+  /p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      yocto-queue: 1.2.2
+    dev: true
+
   /p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
     engines: {node: '>=4'}
@@ -3396,6 +3569,18 @@ packages:
       util: 0.10.4
     dev: false
 
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
+  /pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    dev: true
+
+  /pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
@@ -3423,6 +3608,14 @@ packages:
       load-json-file: 4.0.0
     dev: true
 
+  /pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+    dev: true
+
   /postcss@8.4.18:
     resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3435,6 +3628,15 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
     dev: true
 
   /process-nextick-args@2.0.1:
@@ -3495,6 +3697,10 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    dev: true
+
+  /react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
     dev: true
 
   /react-refresh@0.14.0:
@@ -3833,6 +4039,10 @@ packages:
       object-inspect: 1.12.2
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.4:
     resolution: {integrity: sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==}
     dev: true
@@ -3925,6 +4135,10 @@ packages:
       stackframe: 1.2.1
     dev: false
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
   /stackframe@1.2.1:
     resolution: {integrity: sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==}
     dev: false
@@ -3943,6 +4157,10 @@ packages:
       stack-generator: 2.0.5
       stacktrace-gps: 3.0.4
     dev: false
+
+  /std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    dev: true
 
   /stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -4035,6 +4253,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+    dependencies:
+      acorn: 8.16.0
+    dev: true
+
   /stylis@4.1.1:
     resolution: {integrity: sha512-lVrM/bNdhVX2OgBFNa2YJ9Lxj7kPzylieHd3TNjuGE0Re9JB7joL5VUKOVH1kdNNJTgGPpT8hmwIAPLaSyEVFQ==}
     dev: false
@@ -4113,6 +4337,20 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -4175,6 +4413,11 @@ packages:
       prelude-ls: 1.2.1
     dev: true
 
+  /type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+    dev: true
+
   /type-fest@0.16.0:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
@@ -4211,6 +4454,10 @@ packages:
     hasBin: true
     dev: true
 
+  /ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+    dev: true
+
   /uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -4226,6 +4473,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
     dev: true
 
   /unique-string@2.0.0:
@@ -4282,6 +4533,26 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /vite-node@0.34.6:
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.8.2
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 3.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-plugin-logseq@1.1.2:
     resolution: {integrity: sha512-l5YvoH3K25Zx9eqgoJFug7NfVqSPwq7/FcYYhN1TkdG8ZOiD+c+TAwdCS2dJbGgvx8GmSpbgwSZWgslB+wH53g==}
     dependencies:
@@ -4332,6 +4603,70 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.20
+      '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
+      '@types/node': 25.9.1
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      cac: 6.7.14
+      chai: 4.5.0
+      debug: 4.3.4
+      local-pkg: 0.4.3
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.10.0
+      strip-literal: 1.3.0
+      tinybench: 2.9.0
+      tinypool: 0.7.0
+      vite: 3.2.2
+      vite-node: 0.34.6
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
@@ -4359,6 +4694,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /windicss@3.5.6:
@@ -4429,4 +4773,9 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
     dev: true

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,8 @@
-# Logseq Plugin Tabs
+# Logseq Plugin Tabs Scrollable
 
-### 🔔 Looking for maintainers! 🔔
+This project is a maintained fork of [`pengx17/logseq-plugin-tabs`](https://github.com/pengx17/logseq-plugin-tabs) that adds wheel scrolling for overflowing tabs while keeping the original tabbed-page workflow intact.
 
-[![Github All Releases](https://img.shields.io/github/downloads/pengx17/logseq-plugin-tabs/total.svg)](https://github.com/pengx17/logseq-plugin-tabs/releases)
-
-A plugin that let's you to manage your working pages with tabs.
+It helps you manage your working pages with tabs.
 
 UX is mainly brought from modern browsers:
 
@@ -16,6 +14,12 @@ UX is mainly brought from modern browsers:
 - tabs info will be persisted in your local storage, so that your tabs will recover even if you re-open the app
 
 ![](./demo.gif)
+
+## Fork notes
+
+- Adds wheel scrolling for overflowing tabs in the tab bar.
+- Preserves attribution to the upstream `pengx17/logseq-plugin-tabs` project.
+- Continues under the same MIT license lineage as the upstream project.
 
 ## Keyboard shortcuts
 

--- a/release.config.js
+++ b/release.config.js
@@ -20,13 +20,13 @@ module.exports = {
       "@semantic-release/exec",
       {
         prepareCmd:
-          "zip -qq -r logseq-plugin-tabs-${nextRelease.version}.zip dist readme.md LICENSE package.json",
+          "zip -qq -r logseq-plugin-tabs-scrollable-${nextRelease.version}.zip dist readme.md LICENSE package.json",
       },
     ],
     [
       "@semantic-release/github",
       {
-        assets: "logseq-plugin-tabs-*.zip",
+        assets: "logseq-plugin-tabs-scrollable-*.zip",
       },
     ],
   ],

--- a/src/PageTabs.tsx
+++ b/src/PageTabs.tsx
@@ -6,8 +6,14 @@ import produce from "immer";
 import React from "react";
 import { useDeepCompareEffect, useLatest } from "react-use";
 import "./PageTabs.css";
+import {
+  clearCommandHandlers,
+  registerCommandPaletteOnce,
+} from "./commandRegistry";
 import { keyBindings } from "./settings";
+import { resolveWheelScroll } from "./tabStripWheel";
 import { ITabInfo } from "./types";
+import { attachNonPassiveWheelListener } from "./wheelListener";
 import {
   delay,
   getSourcePage,
@@ -70,7 +76,7 @@ interface TabsProps {
   onSwapTab: (tab: ITabInfo, anotherTab: ITabInfo) => void;
 }
 
-const Tabs = React.forwardRef<HTMLElement, TabsProps>(
+const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
   (
     {
       activeTab,
@@ -87,6 +93,34 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
     ref
   ) => {
     const [draggingTab, setDraggingTab] = React.useState<ITabInfo>();
+
+    React.useEffect(() => {
+      const element = (ref as React.RefObject<HTMLDivElement | null>)?.current;
+      if (!element) {
+        return;
+      }
+
+      const onWheel = (event: WheelEvent) => {
+        const input = {
+          scrollLeft: element.scrollLeft,
+          clientWidth: element.clientWidth,
+          scrollWidth: element.scrollWidth,
+          deltaX: event.deltaX,
+          deltaY: event.deltaY,
+          deltaMode: event.deltaMode,
+        };
+        const result = resolveWheelScroll(input);
+
+        if (!result.shouldConsume) {
+          return;
+        }
+
+        event.preventDefault();
+        element.scrollLeft = result.nextScrollLeft;
+      };
+
+      return attachNonPassiveWheelListener(element, onWheel);
+    }, [ref]);
 
     React.useEffect(() => {
       const dragEndListener = () => {
@@ -116,17 +150,20 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
     }
     return (
       <div
-        // @ts-expect-error ???
         ref={ref}
         data-dragging={draggingTab != null}
-        className={`logseq-tab-wrapper flex items-center h-full px-1`}
-        style={{ width: "fit-content" }}
+        className="h-full w-full overflow-x-auto overflow-y-hidden px-1"
         // By default middle button click will enter the horizontal scroll mode
         onMouseDown={(e) => {
           if (e.button === 1) e.preventDefault();
         }}
       >
-        {tabs.map((tab) => {
+        <div
+          data-dragging={draggingTab != null}
+          className="logseq-tab-wrapper flex items-center h-full"
+          style={{ width: "fit-content" }}
+        >
+          {tabs.map((tab) => {
           const isActive = isTabEqual(tab, activeTab);
           const onClose: React.MouseEventHandler = (e) => {
             e.stopPropagation();
@@ -156,13 +193,6 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
             <div
               onClick={(e) => onClickTab(tab, e.shiftKey)}
               onDoubleClick={() => onPinTab(tab)}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                console.log(e);
-                // onAuxClick={/*onClose*/}
-                // TODO: show the same context menu like right-clicking the title?
-                console.log("Not implemented yet");
-              }}
               key={[tab.originalName, tab.uuid].join("-")}
               data-active={isActive}
               data-pinned={tab.pinned}
@@ -215,6 +245,7 @@ const Tabs = React.forwardRef<HTMLElement, TabsProps>(
             <span className="logseq-tab-title">Close All</span>
           </div>
         )}
+        </div>
       </div>
     );
   }
@@ -472,9 +503,6 @@ const sortTabs = (tabs: ITabInfo[]) => {
   });
 };
 
-// Avoid register issues during dev
-const registeredKeybindings = new Set<string>();
-
 function registerKeybinding(
   setting: {
     key: string;
@@ -483,11 +511,15 @@ function registerKeybinding(
   },
   cb: () => void
 ) {
-  if (registeredKeybindings.has(setting.key)) {
-    return;
-  }
-  registeredKeybindings.add(setting.key);
-  logseq.App.registerCommandPalette(setting, cb);
+  registerCommandPaletteOnce({
+    host: parent.window,
+    pluginId: logseq.baseInfo.id,
+    key: setting.key,
+    register: (action) => {
+      logseq.App.registerCommandPalette(setting, action);
+    },
+    handler: cb,
+  });
 }
 
 const useRegisterKeybindings = (
@@ -568,6 +600,12 @@ const useRegisterCloseAllButPins = (cb: (b: boolean) => void) => {
 };
 
 export function PageTabs(): JSX.Element {
+  React.useEffect(() => {
+    return () => {
+      clearCommandHandlers(parent.window, logseq.baseInfo.id);
+    };
+  }, []);
+
   const [tabs, setTabs] = useStoreTabs();
   const [activeTab, setActiveTab] = useActiveTab(tabs);
 
@@ -750,7 +788,7 @@ export function PageTabs(): JSX.Element {
     );
   };
 
-  const ref = React.useRef<HTMLElement>(null);
+  const ref = React.useRef<HTMLDivElement>(null);
   const scrollWidth = useScrollWidth(ref);
 
   useAdaptMainUIStyle(tabs.length > 0, scrollWidth);

--- a/src/commandRegistry.test.ts
+++ b/src/commandRegistry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearCommandHandlers,
+  registerCommandPaletteOnce,
+} from "./commandRegistry";
+
+describe("registerCommandPaletteOnce", () => {
+  it("registers a command once and dispatches to the latest handler", () => {
+    const host = {};
+    const firstHandler = vi.fn();
+    const latestHandler = vi.fn();
+    const register = vi.fn();
+    let action!: () => void;
+
+    register.mockImplementation((registeredAction: () => void) => {
+      action = registeredAction;
+    });
+
+    expect(
+      registerCommandPaletteOnce({
+        host,
+        pluginId: "_logseq-plugin-tabs-scrollable",
+        key: "tabs-close-all",
+        register,
+        handler: firstHandler,
+      })
+    ).toBe(true);
+
+    action();
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+
+    expect(
+      registerCommandPaletteOnce({
+        host,
+        pluginId: "_logseq-plugin-tabs-scrollable",
+        key: "tabs-close-all",
+        register,
+        handler: latestHandler,
+      })
+    ).toBe(false);
+
+    action();
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(latestHandler).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps handlers isolated by plugin id and clears them on unload", () => {
+    const host = {};
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+    let firstAction!: () => void;
+    let secondAction!: () => void;
+
+    registerCommandPaletteOnce({
+      host,
+      pluginId: "_logseq-plugin-tabs-scrollable",
+      key: "tabs-close-all",
+      register: (action: () => void) => {
+        firstAction = action;
+      },
+      handler: firstHandler,
+    });
+
+    registerCommandPaletteOnce({
+      host,
+      pluginId: "_different-plugin",
+      key: "tabs-close-all",
+      register: (action: () => void) => {
+        secondAction = action;
+      },
+      handler: secondHandler,
+    });
+
+    clearCommandHandlers(host, "_logseq-plugin-tabs-scrollable");
+
+    firstAction();
+    secondAction();
+
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commandRegistry.ts
+++ b/src/commandRegistry.ts
@@ -1,0 +1,78 @@
+type CommandHandler = () => void;
+
+type HostCommandRegistry = {
+  handlers: Map<string, CommandHandler>;
+  registered: Set<string>;
+};
+
+type RegisterCommandPaletteOnceArgs = {
+  host: object;
+  pluginId: string;
+  key: string;
+  register: (action: CommandHandler) => void;
+  handler: CommandHandler;
+};
+
+const hostRegistries = new WeakMap<object, HostCommandRegistry>();
+
+function getNamespacedKey(pluginId: string, key: string): string {
+  return `${pluginId}:${key}`;
+}
+
+function getRegistry(host: object): HostCommandRegistry {
+  const existing = hostRegistries.get(host);
+  if (existing) {
+    return existing;
+  }
+
+  const created: HostCommandRegistry = {
+    handlers: new Map<string, CommandHandler>(),
+    registered: new Set<string>(),
+  };
+  hostRegistries.set(host, created);
+  return created;
+}
+
+export function registerCommandPaletteOnce({
+  host,
+  pluginId,
+  key,
+  register,
+  handler,
+}: RegisterCommandPaletteOnceArgs): boolean {
+  const registry = getRegistry(host);
+  const namespacedKey = getNamespacedKey(pluginId, key);
+
+  registry.handlers.set(namespacedKey, handler);
+
+  if (registry.registered.has(namespacedKey)) {
+    return false;
+  }
+
+  register(() => {
+    registry.handlers.get(namespacedKey)?.();
+  });
+  registry.registered.add(namespacedKey);
+  return true;
+}
+
+export function clearCommandHandlers(host: object, pluginId: string): void {
+  const registry = hostRegistries.get(host);
+  if (!registry) {
+    return;
+  }
+
+  const prefix = `${pluginId}:`;
+
+  for (const key of registry.handlers.keys()) {
+    if (key.startsWith(prefix)) {
+      registry.handlers.delete(key);
+    }
+  }
+
+  for (const key of registry.registered.keys()) {
+    if (key.startsWith(prefix)) {
+      registry.registered.delete(key);
+    }
+  }
+}

--- a/src/storageKeys.test.ts
+++ b/src/storageKeys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getStorageKeyId } from "./storageKeys";
+
+describe("getStorageKeyId", () => {
+  it("uses the current plugin id when available", () => {
+    (globalThis as any).logseq = {
+      baseInfo: {
+        id: "tabs-scrollable-fork",
+      },
+    };
+
+    expect(getStorageKeyId("graph-path")).toBe(
+      "tabs-scrollable-fork:1.0.0/graph-path"
+    );
+  });
+
+  it("falls back to a fork-specific storage prefix when runtime plugin id is unavailable", () => {
+    (globalThis as any).logseq = {
+      baseInfo: {},
+    };
+
+    expect(getStorageKeyId("graph-path")).toBe(
+      "_logseq-plugin-tabs-scrollable:1.0.0/graph-path"
+    );
+  });
+});

--- a/src/storageKeys.ts
+++ b/src/storageKeys.ts
@@ -1,0 +1,15 @@
+import { schemaVersion } from "../package.json";
+
+type LogseqBaseInfo = {
+  baseInfo?: {
+    id?: string;
+  };
+};
+
+const fallbackPluginId = "_logseq-plugin-tabs-scrollable";
+
+export function getStorageKeyId(graph: string) {
+  const pluginId = (globalThis as typeof globalThis & { logseq?: LogseqBaseInfo })
+    .logseq?.baseInfo?.id || fallbackPluginId;
+  return pluginId + ":" + schemaVersion + "/" + graph;
+}

--- a/src/tabStripWheel.test.ts
+++ b/src/tabStripWheel.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWheelScroll } from "./tabStripWheel";
+
+describe("resolveWheelScroll", () => {
+  it("uses deltaY when vertical intent is dominant", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 20,
+        clientWidth: 100,
+        scrollWidth: 500,
+        deltaX: 10,
+        deltaY: 30,
+        deltaMode: 0,
+      })
+    ).toEqual({
+      nextScrollLeft: 50,
+      shouldConsume: true,
+    });
+  });
+
+  it("uses deltaX when horizontal intent is dominant", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 100,
+        clientWidth: 100,
+        scrollWidth: 500,
+        deltaX: -40,
+        deltaY: 5,
+        deltaMode: 0,
+      })
+    ).toEqual({
+      nextScrollLeft: 60,
+      shouldConsume: true,
+    });
+  });
+
+  it("does not consume when there is no overflow", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 0,
+        clientWidth: 200,
+        scrollWidth: 200,
+        deltaX: 0,
+        deltaY: 40,
+        deltaMode: 0,
+      })
+    ).toEqual({
+      nextScrollLeft: 0,
+      shouldConsume: false,
+    });
+  });
+
+  it("does not consume when already at the left edge and moving farther left", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 0,
+        clientWidth: 100,
+        scrollWidth: 500,
+        deltaX: -5,
+        deltaY: -30,
+        deltaMode: 0,
+      })
+    ).toEqual({
+      nextScrollLeft: 0,
+      shouldConsume: false,
+    });
+  });
+
+  it("clamps and consumes when movement is only partially available", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 180,
+        clientWidth: 100,
+        scrollWidth: 300,
+        deltaX: 0,
+        deltaY: 40,
+        deltaMode: 0,
+      })
+    ).toEqual({
+      nextScrollLeft: 200,
+      shouldConsume: true,
+    });
+  });
+
+  it("normalizes line deltas before applying dominant axis rules", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 10,
+        clientWidth: 100,
+        scrollWidth: 500,
+        deltaX: 1,
+        deltaY: 3,
+        deltaMode: 1,
+      })
+    ).toEqual({
+      nextScrollLeft: 58,
+      shouldConsume: true,
+    });
+  });
+
+  it("normalizes page deltas using the visible width", () => {
+    expect(
+      resolveWheelScroll({
+        scrollLeft: 50,
+        clientWidth: 120,
+        scrollWidth: 500,
+        deltaX: 1,
+        deltaY: 0,
+        deltaMode: 2,
+      })
+    ).toEqual({
+      nextScrollLeft: 170,
+      shouldConsume: true,
+    });
+  });
+
+});

--- a/src/tabStripWheel.ts
+++ b/src/tabStripWheel.ts
@@ -1,0 +1,55 @@
+export type WheelScrollInput = {
+  scrollLeft: number;
+  clientWidth: number;
+  scrollWidth: number;
+  deltaX: number;
+  deltaY: number;
+  deltaMode: number;
+};
+
+export type WheelScrollResult = {
+  nextScrollLeft: number;
+  shouldConsume: boolean;
+};
+
+const LINE_DELTA_PX = 16;
+
+function normalizeDelta(delta: number, deltaMode: number, clientWidth: number): number {
+  if (deltaMode === 1) {
+    return delta * LINE_DELTA_PX;
+  }
+
+  if (deltaMode === 2) {
+    return delta * clientWidth;
+  }
+
+  return delta;
+}
+
+export function resolveWheelScroll(input: WheelScrollInput): WheelScrollResult {
+  const maxScrollLeft = Math.max(0, input.scrollWidth - input.clientWidth);
+
+  if (maxScrollLeft === 0) {
+    return {
+      nextScrollLeft: input.scrollLeft,
+      shouldConsume: false,
+    };
+  }
+
+  const normalizedDeltaX = normalizeDelta(input.deltaX, input.deltaMode, input.clientWidth);
+  const normalizedDeltaY = normalizeDelta(input.deltaY, input.deltaMode, input.clientWidth);
+  const movement =
+    Math.abs(normalizedDeltaY) > Math.abs(normalizedDeltaX)
+      ? normalizedDeltaY
+      : normalizedDeltaX;
+
+  const nextScrollLeft = Math.min(
+    maxScrollLeft,
+    Math.max(0, input.scrollLeft + movement)
+  );
+
+  return {
+    nextScrollLeft,
+    shouldConsume: nextScrollLeft !== input.scrollLeft,
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { useHoverDirty, useMountedState } from "react-use";
 import { schemaVersion } from "../package.json";
 import { ITabInfo } from "./types";
 import { inheritCustomCSSSetting } from "./settings";
+import { getStorageKeyId } from "./storageKeys";
 
 export const useAppVisible = () => {
   const [visible, setVisible] = useState(logseq.isMainUIVisible);
@@ -82,7 +83,7 @@ export const delay = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 function getKeyId(graph: string) {
-  return "logseq-plugin-tabs:" + schemaVersion + "/" + graph;
+  return getStorageKeyId(graph);
 }
 
 const readFromLocalStorage = (graph: string): ITabInfo[] | null => {

--- a/src/wheelListener.test.ts
+++ b/src/wheelListener.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { attachNonPassiveWheelListener } from "./wheelListener";
+
+describe("attachNonPassiveWheelListener", () => {
+  it("registers the wheel listener with passive false and removes it on cleanup", () => {
+    const listener = vi.fn();
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    const element = {
+      addEventListener,
+      removeEventListener,
+    } as unknown as HTMLDivElement;
+
+    const detach = attachNonPassiveWheelListener(element, listener);
+
+    expect(addEventListener).toHaveBeenCalledWith("wheel", expect.any(Function), {
+      passive: false,
+    });
+
+    const nativeListener = addEventListener.mock.calls[0][1] as EventListener;
+    nativeListener({ type: "wheel", deltaY: 15 } as unknown as Event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    detach();
+
+    expect(removeEventListener).toHaveBeenCalledWith("wheel", nativeListener);
+  });
+});

--- a/src/wheelListener.ts
+++ b/src/wheelListener.ts
@@ -1,0 +1,14 @@
+export function attachNonPassiveWheelListener(
+  element: HTMLElement,
+  listener: (event: WheelEvent) => void
+): () => void {
+  const nativeListener: EventListener = (event) => {
+    listener(event as WheelEvent);
+  };
+
+  element.addEventListener("wheel", nativeListener, { passive: false });
+
+  return () => {
+    element.removeEventListener("wheel", nativeListener);
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({});


### PR DESCRIPTION
## Summary
- rename and publish the plugin as a maintained fork under `logseq-plugin-tabs-scrollable`
- isolate persisted storage keys and command registration behavior from the upstream plugin
- add wheel scrolling for overflowing tabs, including non-passive wheel handling for Logseq

## Test Plan
- `npm test -- src/wheelListener.test.ts src/tabStripWheel.test.ts src/commandRegistry.test.ts src/storageKeys.test.ts`
- `npm run build`